### PR TITLE
add noindex header to all pages on testing environment

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -11,6 +11,9 @@ const config: Config = {
   tagline: 'Official Open Data Hub Documentation',
   favicon: 'img/favicon.ico',
 
+  // Prevent search engines from indexing the site when TESTING environment variable is set
+  noIndex: process.env.TESTING === 'true',
+
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
   future: {
     v4: true, // Improve compatibility with the upcoming Docusaurus v4


### PR DESCRIPTION
This pull request introduces a configuration update to prevent search engines from indexing the site when the `TESTING` environment variable is set. This helps ensure that test or staging deployments are not indexed by search engines.

Configuration update:

* Added a `noIndex` property to the Docusaurus config, which is enabled when the `TESTING` environment variable is set to `'true'`.

Based on Docusaurus-Docs: https://docusaurus.io/docs/api/docusaurus-config?utm_source=chatgpt.com#noIndex

The result on the page with `TESTING=true`:
<img width="700" height="72" alt="image" src="https://github.com/user-attachments/assets/e1c08a8c-7ba1-486f-b715-8ebcef5e981d" />
